### PR TITLE
Add tag option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## [Unreleased]
+
+### Added
+* Add :tag option to add custom tags to command output
+
 ## [v0.10.1] - 2021-02-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ Or install it yourself as:
   * [2.3. Logging](#23-logging)
     * [2.3.1. Color](#231-color)
     * [2.3.2. UUID](#232-uuid)
-    * [2.3.3. Only output on error](#233-only-output-on-error)
-    * [2.3.4. Verbose](#234-verbose)
+    * [2.3.3. Tag](#233-tag)
+    * [2.3.4. Only output on error](#234-only-output-on-error)
+    * [2.3.5. Verbose](#235-verbose)
   * [2.4. Dry run](#24-dry-run)
   * [2.5. Wait](#25-wait)
   * [2.6. Test](#26-test)
@@ -221,7 +222,25 @@ cmd.run("echo hello", uuid: false)
 #  Finished in 0.003 seconds with exit status 0 (successful)
 ```
 
-#### 2.3.3 Only output on error
+#### 2.3.3 Tag
+
+You can add custom tags to command output using the `:tag` option. This is useful for categorizing or identifying a specific instance or run of a command:
+
+```ruby
+cmd = TTY::Command.new(tag: "deploy")
+cmd.run("echo hello")
+
+# or individually per command run:  
+cmd = TTY::Command.new
+cmd.run("echo hello", tag: "deploy")
+
+# =>
+#  [deploy] Running echo hello
+#      hello
+#  [deploy] Finished in 0.003 seconds with exit status 0 (successful)
+```
+
+#### 2.3.4 Only output on error
 
 When using a command that can fail, setting `:only_output_on_error` option to `true` hides the output if the command succeeds:
 
@@ -254,7 +273,7 @@ will also print the output.
 
 *Setting this option will cause the output to show at once, at the end of the command.*
 
-#### 2.3.4 Verbose
+#### 2.3.5 Verbose
 
 By default commands will produce warnings when, for example `pty` option is not supported on a given platform. You can switch off such warnings with `:verbose` option set to `false`.
 

--- a/lib/tty/command.rb
+++ b/lib/tty/command.rb
@@ -55,14 +55,16 @@ module TTY
       @output = options.fetch(:output) { $stdout }
       @color   = options.fetch(:color) { true }
       @uuid    = options.fetch(:uuid) { true }
+      @tag     = options[:tag]
       @printer_name = options.fetch(:printer) { :pretty }
       @dry_run = options.fetch(:dry_run) { false }
-      @printer = use_printer(@printer_name, color: @color, uuid: @uuid)
+      @printer = use_printer(@printer_name, color: @color, uuid: @uuid, tag: @tag)
       @cmd_options = {}
       @cmd_options[:verbose] = options.fetch(:verbose, true)
       @cmd_options[:pty] = true if options[:pty]
       @cmd_options[:binmode] = true if options[:binmode]
       @cmd_options[:timeout] = options[:timeout] if options[:timeout]
+      @cmd_options[:tag] = @tag if @tag
     end
 
     # Start external executable in a child process

--- a/lib/tty/command.rb
+++ b/lib/tty/command.rb
@@ -58,7 +58,9 @@ module TTY
       @tag     = options[:tag]
       @printer_name = options.fetch(:printer) { :pretty }
       @dry_run = options.fetch(:dry_run) { false }
-      @printer = use_printer(@printer_name, color: @color, uuid: @uuid, tag: @tag)
+      @printer = use_printer(
+        @printer_name, color: @color, uuid: @uuid, tag: @tag
+      )
       @cmd_options = {}
       @cmd_options[:verbose] = options.fetch(:verbose, true)
       @cmd_options[:pty] = true if options[:pty]

--- a/lib/tty/command/cmd.rb
+++ b/lib/tty/command/cmd.rb
@@ -123,6 +123,12 @@ module TTY
       def with_clean_env
       end
 
+      # The command tag
+      # @api public
+      def tag
+        @options[:tag]
+      end
+
       # Assemble full command
       #
       # @api public
@@ -140,7 +146,8 @@ module TTY
         {
           command: command,
           argv: argv,
-          uuid: uuid
+          uuid: uuid,
+          tag: @options[:tag]
         }
       end
 

--- a/lib/tty/command/printers/pretty.rb
+++ b/lib/tty/command/printers/pretty.rb
@@ -9,6 +9,7 @@ module TTY
         def initialize(*)
           super
           @uuid = options.fetch(:uuid, true)
+          @tag  = options[:tag]
         end
 
         def print_command_start(cmd, *args)
@@ -46,10 +47,10 @@ module TTY
         def write(cmd, message, data = nil)
           cmd_set_uuid = cmd.options.fetch(:uuid, true)
           uuid_needed = cmd.options[:uuid].nil? ? @uuid : cmd_set_uuid
+          prefix = cmd.tag || @tag || (uuid_needed ? cmd.uuid : nil)
+
           out = []
-          if uuid_needed
-            out << "[#{decorate(cmd.uuid, :green)}] " unless cmd.uuid.nil?
-          end
+          out << "[#{decorate(prefix, :green)}] " if prefix
           out << "#{message}\n"
           target = (cmd.only_output_on_error && !data.nil?) ? data : output
           target << out.join

--- a/spec/unit/run_spec.rb
+++ b/spec/unit/run_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe TTY::Command, "#run" do
       "[\e[32m#{uuid}\e[0m] Running \e[33;1mecho hello\e[0m\n",
       "[\e[32m#{uuid}\e[0m] \thello\n",
       "[\e[32m#{uuid}\e[0m] Finished in x seconds with exit status 0 " \
-        "(\e[32;1msuccessful\e[0m)\n"
+      "(\e[32;1msuccessful\e[0m)\n"
     ])
   end
 
@@ -58,7 +58,7 @@ RSpec.describe TTY::Command, "#run" do
       "[\e[32m#{uuid}\e[0m] Running \e[33;1mruby #{non_zero_exit}\e[0m\n",
       "[\e[32m#{uuid}\e[0m] \tnooo\n",
       "[\e[32m#{uuid}\e[0m] Finished in x seconds with exit status 1 " \
-        "(\e[31;1mfailed\e[0m)\n"
+      "(\e[31;1mfailed\e[0m)\n"
     ])
   end
 
@@ -121,12 +121,12 @@ RSpec.describe TTY::Command, "#run" do
       "[\e[32m#{uuid}\e[0m] Running \e[33;1mruby #{phased_output}\e[0m\n",
       "[\e[32m#{uuid}\e[0m] \t..........\n",
       "[\e[32m#{uuid}\e[0m] Finished in x seconds with exit status 0 " \
-        "(\e[32;1msuccessful\e[0m)\n"
+      "(\e[32;1msuccessful\e[0m)\n"
     ])
   end
 
   it "does not persist environment variables",
-    unless: RSpec::Support::OS.windows? do
+     unless: RSpec::Support::OS.windows? do
     output = StringIO.new
     command = TTY::Command.new(output: output)
 
@@ -229,7 +229,7 @@ RSpec.describe TTY::Command, "#run" do
         "[\e[32m#{prefix}\e[0m] Running \e[33;1mecho hello\e[0m\n",
         "[\e[32m#{prefix}\e[0m] \thello\n",
         "[\e[32m#{prefix}\e[0m] Finished in x seconds with exit status 0 " \
-          "(\e[32;1msuccessful\e[0m)\n"
+        "(\e[32;1msuccessful\e[0m)\n"
       ]
     else
       [

--- a/spec/unit/run_spec.rb
+++ b/spec/unit/run_spec.rb
@@ -12,16 +12,14 @@ RSpec.describe TTY::Command, "#run" do
   end
 
   it "runs command successfully with logging" do
-    output = StringIO.new
     uuid = "xxxx"
     allow(SecureRandom).to receive(:uuid).and_return(uuid)
-    command = TTY::Command.new(output: output)
 
-    command.run(:echo, "hello")
+    lines = retrieve_log_lines do |output|
+      command = TTY::Command.new(output: output)
+      command.run(:echo, "hello")
+    end
 
-    output.rewind
-    lines = output.readlines
-    lines.last.gsub!(/\d+\.\d+/, "x")
     expect(lines).to eq([
       "[\e[32m#{uuid}\e[0m] Running \e[33;1mecho hello\e[0m\n",
       "[\e[32m#{uuid}\e[0m] \thello\n",
@@ -31,16 +29,14 @@ RSpec.describe TTY::Command, "#run" do
   end
 
   it "runs command successfully with logging without color" do
-    output = StringIO.new
     uuid = "xxxx"
     allow(SecureRandom).to receive(:uuid).and_return(uuid)
-    command = TTY::Command.new(output: output, color: false)
 
-    command.run(:echo, "hello")
+    lines = retrieve_log_lines do |output|
+      command = TTY::Command.new(output: output, color: false)
+      command.run(:echo, "hello")
+    end
 
-    output.rewind
-    lines = output.readlines
-    lines.last.gsub!(/\d+\.\d+/, "x")
     expect(lines).to eq([
       "[#{uuid}] Running echo hello\n",
       "[#{uuid}] \thello\n",
@@ -50,16 +46,14 @@ RSpec.describe TTY::Command, "#run" do
 
   it "runs command and fails with logging" do
     non_zero_exit = fixtures_path("non_zero_exit")
-    output = StringIO.new
     uuid = "xxxx"
     allow(SecureRandom).to receive(:uuid).and_return(uuid)
-    command = TTY::Command.new(output: output)
 
-    command.run!("ruby #{non_zero_exit}")
+    lines = retrieve_log_lines do |output|
+      command = TTY::Command.new(output: output)
+      command.run!("ruby #{non_zero_exit}")
+    end
 
-    output.rewind
-    lines = output.readlines
-    lines.last.gsub!(/\d+\.\d+/, "x")
     expect(lines).to eq([
       "[\e[32m#{uuid}\e[0m] Running \e[33;1mruby #{non_zero_exit}\e[0m\n",
       "[\e[32m#{uuid}\e[0m] \tnooo\n",
@@ -113,17 +107,16 @@ RSpec.describe TTY::Command, "#run" do
     phased_output = fixtures_path("phased_output")
     uuid = "xxxx"
     allow(SecureRandom).to receive(:uuid).and_return(uuid)
-    output = StringIO.new
-    cmd = TTY::Command.new(output: output)
 
-    out, err = cmd.run("ruby #{phased_output}")
+    out = err = nil
+    lines = retrieve_log_lines do |output|
+      cmd = TTY::Command.new(output: output)
+      out, err = cmd.run("ruby #{phased_output}")
+    end
 
     expect(out).to eq("." * 10)
     expect(err).to eq("")
 
-    output.rewind
-    lines = output.readlines
-    lines.last.gsub!(/\d+\.\d+/, "x")
     expect(lines).to eq([
       "[\e[32m#{uuid}\e[0m] Running \e[33;1mruby #{phased_output}\e[0m\n",
       "[\e[32m#{uuid}\e[0m] \t..........\n",
@@ -155,28 +148,22 @@ RSpec.describe TTY::Command, "#run" do
 
   context "with uuid option" do
     it "runs command successfully with logging without uuid set globally" do
-      output = StringIO.new
-      command = TTY::Command.new(output: output, uuid: false)
+      lines = retrieve_log_lines do |output|
+        command = TTY::Command.new(output: output, uuid: false)
+        command.run(:echo, "hello")
+      end
 
-      command.run(:echo, "hello")
-      output.rewind
-
-      lines = output.readlines
-      lines.last.gsub!(/\d+\.\d+/, "x")
       expect(lines).to eq(
         generic_colored_log_lines(prefix: nil)
       )
     end
 
     it "runs command successfully with logging without uuid set locally" do
-      output = StringIO.new
-      command = TTY::Command.new(output: output)
+      lines = retrieve_log_lines do |output|
+        command = TTY::Command.new(output: output)
+        command.run(:echo, "hello", uuid: false)
+      end
 
-      command.run(:echo, "hello", uuid: false)
-      output.rewind
-
-      lines = output.readlines
-      lines.last.gsub!(/\d+\.\d+/, "x")
       expect(lines).to eq(
         generic_colored_log_lines(prefix: nil)
       )
@@ -185,49 +172,54 @@ RSpec.describe TTY::Command, "#run" do
 
   context "with tag option" do
     it "prints the tag set globally" do
-      output = StringIO.new
       tag = "task"
-      command = TTY::Command.new(output: output, tag: tag)
 
-      command.run(:echo, "hello")
+      lines = retrieve_log_lines do |output|
+        command = TTY::Command.new(output: output, tag: tag)
+        command.run(:echo, "hello")
+      end
 
-      output.rewind
-      lines = output.readlines
-      lines.last.gsub!(/\d+\.\d+/, "x")
       expect(lines).to eq(
         generic_colored_log_lines(prefix: tag)
       )
     end
 
     it "prints the tag set locally" do
-      output = StringIO.new
       tag = "task"
-      command = TTY::Command.new(output: output)
 
-      command.run(:echo, "hello", tag: tag)
+      lines = retrieve_log_lines do |output|
+        command = TTY::Command.new(output: output)
+        command.run(:echo, "hello", tag: tag)
+      end
 
-      output.rewind
-      lines = output.readlines
-      lines.last.gsub!(/\d+\.\d+/, "x")
       expect(lines).to eq(
         generic_colored_log_lines(prefix: tag)
       )
     end
 
     it "prints the tag even if uuid is set to false" do
-      output = StringIO.new
       tag = "task"
-      command = TTY::Command.new(output: output, tag: tag, uuid: false)
 
-      command.run(:echo, "hello")
+      lines = retrieve_log_lines do |output|
+        command = TTY::Command.new(output: output, tag: tag, uuid: false)
+        command.run(:echo, "hello")
+      end
 
-      output.rewind
-      lines = output.readlines
-      lines.last.gsub!(/\d+\.\d+/, "x")
       expect(lines).to eq(
         generic_colored_log_lines(prefix: tag)
       )
     end
+  end
+
+  # Retrieves log lines from the output produced within the given block.
+  # Also replaces the execution time portion in the output with `x`.
+  def retrieve_log_lines
+    output = StringIO.new
+    yield(output)
+    output.rewind
+    lines = output.readlines
+    lines.last.gsub!(/\d+\.\d+/, "x")
+    lines
   end
 
   # Generates the expected log lines in colored mode, with/without `[prefix]`

--- a/spec/unit/run_spec.rb
+++ b/spec/unit/run_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe TTY::Command, "#run" do
       "[\e[32m#{uuid}\e[0m] Running \e[33;1mecho hello\e[0m\n",
       "[\e[32m#{uuid}\e[0m] \thello\n",
       "[\e[32m#{uuid}\e[0m] Finished in x seconds with exit status 0 " \
-      "(\e[32;1msuccessful\e[0m)\n"
+        "(\e[32;1msuccessful\e[0m)\n"
     ])
   end
 
@@ -48,9 +48,110 @@ RSpec.describe TTY::Command, "#run" do
     ])
   end
 
-  # TODO:
-  #   Move "with xxx option" context to the end of
-  #   the describe block to follow RSpec style guide.
+  it "runs command and fails with logging" do
+    non_zero_exit = fixtures_path("non_zero_exit")
+    output = StringIO.new
+    uuid = "xxxx"
+    allow(SecureRandom).to receive(:uuid).and_return(uuid)
+    command = TTY::Command.new(output: output)
+
+    command.run!("ruby #{non_zero_exit}")
+
+    output.rewind
+    lines = output.readlines
+    lines.last.gsub!(/\d+\.\d+/, "x")
+    expect(lines).to eq([
+      "[\e[32m#{uuid}\e[0m] Running \e[33;1mruby #{non_zero_exit}\e[0m\n",
+      "[\e[32m#{uuid}\e[0m] \tnooo\n",
+      "[\e[32m#{uuid}\e[0m] Finished in x seconds with exit status 1 " \
+        "(\e[31;1mfailed\e[0m)\n"
+    ])
+  end
+
+  it "raises ExitError on command failure" do
+    non_zero_exit = fixtures_path("non_zero_exit")
+    output = StringIO.new
+    command = TTY::Command.new(output: output)
+
+    expect {
+      command.run("ruby #{non_zero_exit}")
+    }.to raise_error(TTY::Command::ExitError, [
+      "Running `ruby #{non_zero_exit}` failed with",
+      "  exit status: 1",
+      "  stdout: nooo",
+      "  stderr: Nothing written\n"
+    ].join("\n"))
+  end
+
+  it "streams output data" do
+    stream = fixtures_path("stream")
+    out_stream = StringIO.new
+    command = TTY::Command.new(output: out_stream)
+    output = []
+    error = []
+
+    command.run("ruby #{stream}") do |out, err|
+      output << out if out
+      error << err if err
+    end
+
+    expect(output.join.gsub(/\r\n|\n/, "")).to eq("hello 1hello 2hello 3")
+    expect(error.join).to eq("")
+  end
+
+  it "preserves ANSI codes" do
+    output = StringIO.new
+    command = TTY::Command.new(output: output, printer: :quiet)
+
+    out, = command.run("echo \e[35mhello\e[0m")
+
+    expect(out.chomp).to eq("\e[35mhello\e[0m")
+    expect(output.string.chomp).to eq("\e[35mhello\e[0m")
+  end
+
+  it "logs phased output in one line" do
+    phased_output = fixtures_path("phased_output")
+    uuid = "xxxx"
+    allow(SecureRandom).to receive(:uuid).and_return(uuid)
+    output = StringIO.new
+    cmd = TTY::Command.new(output: output)
+
+    out, err = cmd.run("ruby #{phased_output}")
+
+    expect(out).to eq("." * 10)
+    expect(err).to eq("")
+
+    output.rewind
+    lines = output.readlines
+    lines.last.gsub!(/\d+\.\d+/, "x")
+    expect(lines).to eq([
+      "[\e[32m#{uuid}\e[0m] Running \e[33;1mruby #{phased_output}\e[0m\n",
+      "[\e[32m#{uuid}\e[0m] \t..........\n",
+      "[\e[32m#{uuid}\e[0m] Finished in x seconds with exit status 0 " \
+        "(\e[32;1msuccessful\e[0m)\n"
+    ])
+  end
+
+  it "does not persist environment variables",
+    unless: RSpec::Support::OS.windows? do
+    output = StringIO.new
+    command = TTY::Command.new(output: output)
+
+    command.run(:echo, "hello", env: { foo: 1 })
+
+    output.rewind
+    lines = output.readlines
+    expect(lines[0])
+      .to include("Running \e[33;1m( export FOO=\"1\" ; echo hello )\e[0m\n")
+
+    output.reopen
+
+    command.run(:echo, "hello")
+
+    output.rewind
+    lines = output.readlines
+    expect(lines[0]).to include("Running \e[33;1mecho hello\e[0m\n")
+  end
 
   context "with uuid option" do
     it "runs command successfully with logging without uuid set globally" do
@@ -129,111 +230,6 @@ RSpec.describe TTY::Command, "#run" do
     end
   end
 
-  it "runs command and fails with logging" do
-    non_zero_exit = fixtures_path("non_zero_exit")
-    output = StringIO.new
-    uuid = "xxxx"
-    allow(SecureRandom).to receive(:uuid).and_return(uuid)
-    command = TTY::Command.new(output: output)
-
-    command.run!("ruby #{non_zero_exit}")
-
-    output.rewind
-    lines = output.readlines
-    lines.last.gsub!(/\d+\.\d+/, "x")
-    expect(lines).to eq([
-      "[\e[32m#{uuid}\e[0m] Running \e[33;1mruby #{non_zero_exit}\e[0m\n",
-      "[\e[32m#{uuid}\e[0m] \tnooo\n",
-      "[\e[32m#{uuid}\e[0m] Finished in x seconds with exit status 1 " \
-      "(\e[31;1mfailed\e[0m)\n"
-    ])
-  end
-
-  it "raises ExitError on command failure" do
-    non_zero_exit = fixtures_path("non_zero_exit")
-    output = StringIO.new
-    command = TTY::Command.new(output: output)
-
-    expect {
-      command.run("ruby #{non_zero_exit}")
-    }.to raise_error(TTY::Command::ExitError, [
-      "Running `ruby #{non_zero_exit}` failed with",
-      "  exit status: 1",
-      "  stdout: nooo",
-      "  stderr: Nothing written\n"
-    ].join("\n"))
-  end
-
-  it "streams output data" do
-    stream = fixtures_path("stream")
-    out_stream = StringIO.new
-    command = TTY::Command.new(output: out_stream)
-    output = []
-    error = []
-
-    command.run("ruby #{stream}") do |out, err|
-      output << out if out
-      error << err if err
-    end
-
-    expect(output.join.gsub(/\r\n|\n/, "")).to eq("hello 1hello 2hello 3")
-    expect(error.join).to eq("")
-  end
-
-  it "preserves ANSI codes" do
-    output = StringIO.new
-    command = TTY::Command.new(output: output, printer: :quiet)
-
-    out, = command.run("echo \e[35mhello\e[0m")
-
-    expect(out.chomp).to eq("\e[35mhello\e[0m")
-    expect(output.string.chomp).to eq("\e[35mhello\e[0m")
-  end
-
-  it "logs phased output in one line" do
-    phased_output = fixtures_path("phased_output")
-    uuid = "xxxx"
-    allow(SecureRandom).to receive(:uuid).and_return(uuid)
-    output = StringIO.new
-    cmd = TTY::Command.new(output: output)
-
-    out, err = cmd.run("ruby #{phased_output}")
-
-    expect(out).to eq("." * 10)
-    expect(err).to eq("")
-
-    output.rewind
-    lines = output.readlines
-    lines.last.gsub!(/\d+\.\d+/, "x")
-    expect(lines).to eq([
-      "[\e[32m#{uuid}\e[0m] Running \e[33;1mruby #{phased_output}\e[0m\n",
-      "[\e[32m#{uuid}\e[0m] \t..........\n",
-      "[\e[32m#{uuid}\e[0m] Finished in x seconds with exit status 0 " \
-      "(\e[32;1msuccessful\e[0m)\n"
-    ])
-  end
-
-  it "does not persist environment variables",
-     unless: RSpec::Support::OS.windows? do
-    output = StringIO.new
-    command = TTY::Command.new(output: output)
-
-    command.run(:echo, "hello", env: { foo: 1 })
-
-    output.rewind
-    lines = output.readlines
-    expect(lines[0])
-      .to include("Running \e[33;1m( export FOO=\"1\" ; echo hello )\e[0m\n")
-
-    output.reopen
-
-    command.run(:echo, "hello")
-
-    output.rewind
-    lines = output.readlines
-    expect(lines[0]).to include("Running \e[33;1mecho hello\e[0m\n")
-  end
-
   # Generates the expected log lines in colored mode, with/without `[prefix]`
   def generic_colored_log_lines(prefix: nil)
     if prefix
@@ -241,7 +237,7 @@ RSpec.describe TTY::Command, "#run" do
         "[\e[32m#{prefix}\e[0m] Running \e[33;1mecho hello\e[0m\n",
         "[\e[32m#{prefix}\e[0m] \thello\n",
         "[\e[32m#{prefix}\e[0m] Finished in x seconds with exit status 0 " \
-        "(\e[32;1msuccessful\e[0m)\n"
+          "(\e[32;1msuccessful\e[0m)\n"
       ]
     else
       [

--- a/spec/unit/run_spec.rb
+++ b/spec/unit/run_spec.rb
@@ -62,11 +62,9 @@ RSpec.describe TTY::Command, "#run" do
 
       lines = output.readlines
       lines.last.gsub!(/\d+\.\d+/, "x")
-      expect(lines).to eq([
-        "Running \e[33;1mecho hello\e[0m\n",
-        "\thello\n",
-        "Finished in x seconds with exit status 0 (\e[32;1msuccessful\e[0m)\n"
-      ])
+      expect(lines).to eq(
+        generic_colored_log_lines(prefix: nil)
+      )
     end
 
     it "runs command successfully with logging without uuid set locally" do
@@ -78,11 +76,9 @@ RSpec.describe TTY::Command, "#run" do
 
       lines = output.readlines
       lines.last.gsub!(/\d+\.\d+/, "x")
-      expect(lines).to eq([
-        "Running \e[33;1mecho hello\e[0m\n",
-        "\thello\n",
-        "Finished in x seconds with exit status 0 (\e[32;1msuccessful\e[0m)\n"
-      ])
+      expect(lines).to eq(
+        generic_colored_log_lines(prefix: nil)
+      )
     end
   end
 
@@ -97,12 +93,9 @@ RSpec.describe TTY::Command, "#run" do
       output.rewind
       lines = output.readlines
       lines.last.gsub!(/\d+\.\d+/, "x")
-      expect(lines).to eq([
-        "[\e[32m#{tag}\e[0m] Running \e[33;1mecho hello\e[0m\n",
-        "[\e[32m#{tag}\e[0m] \thello\n",
-        "[\e[32m#{tag}\e[0m] Finished in x seconds with exit status 0 " \
-        "(\e[32;1msuccessful\e[0m)\n"
-      ])
+      expect(lines).to eq(
+        generic_colored_log_lines(prefix: tag)
+      )
     end
 
     it "prints the tag set locally" do
@@ -115,12 +108,9 @@ RSpec.describe TTY::Command, "#run" do
       output.rewind
       lines = output.readlines
       lines.last.gsub!(/\d+\.\d+/, "x")
-      expect(lines).to eq([
-        "[\e[32m#{tag}\e[0m] Running \e[33;1mecho hello\e[0m\n",
-        "[\e[32m#{tag}\e[0m] \thello\n",
-        "[\e[32m#{tag}\e[0m] Finished in x seconds with exit status 0 " \
-        "(\e[32;1msuccessful\e[0m)\n"
-      ])
+      expect(lines).to eq(
+        generic_colored_log_lines(prefix: tag)
+      )
     end
 
     it "prints the tag even if uuid is set to false" do
@@ -133,12 +123,9 @@ RSpec.describe TTY::Command, "#run" do
       output.rewind
       lines = output.readlines
       lines.last.gsub!(/\d+\.\d+/, "x")
-      expect(lines).to eq([
-        "[\e[32m#{tag}\e[0m] Running \e[33;1mecho hello\e[0m\n",
-        "[\e[32m#{tag}\e[0m] \thello\n",
-        "[\e[32m#{tag}\e[0m] Finished in x seconds with exit status 0 " \
-        "(\e[32;1msuccessful\e[0m)\n"
-      ])
+      expect(lines).to eq(
+        generic_colored_log_lines(prefix: tag)
+      )
     end
   end
 
@@ -245,5 +232,23 @@ RSpec.describe TTY::Command, "#run" do
     output.rewind
     lines = output.readlines
     expect(lines[0]).to include("Running \e[33;1mecho hello\e[0m\n")
+  end
+
+  # Generates the expected log lines in colored mode, with/without `[prefix]`
+  def generic_colored_log_lines(prefix: nil)
+    if prefix
+      [
+        "[\e[32m#{prefix}\e[0m] Running \e[33;1mecho hello\e[0m\n",
+        "[\e[32m#{prefix}\e[0m] \thello\n",
+        "[\e[32m#{prefix}\e[0m] Finished in x seconds with exit status 0 " \
+        "(\e[32;1msuccessful\e[0m)\n"
+      ]
+    else
+      [
+        "Running \e[33;1mecho hello\e[0m\n",
+        "\thello\n",
+        "Finished in x seconds with exit status 0 (\e[32;1msuccessful\e[0m)\n"
+      ]
+    end
   end
 end

--- a/spec/unit/run_spec.rb
+++ b/spec/unit/run_spec.rb
@@ -48,36 +48,98 @@ RSpec.describe TTY::Command, "#run" do
     ])
   end
 
-  it "runs command successfully with logging without uuid set globally" do
-    output = StringIO.new
-    command = TTY::Command.new(output: output, uuid: false)
+  # TODO:
+  #   Move "with xxx option" context to the end of
+  #   the describe block to follow RSpec style guide.
 
-    command.run(:echo, "hello")
-    output.rewind
+  context "with uuid option" do
+    it "runs command successfully with logging without uuid set globally" do
+      output = StringIO.new
+      command = TTY::Command.new(output: output, uuid: false)
 
-    lines = output.readlines
-    lines.last.gsub!(/\d+\.\d+/, "x")
-    expect(lines).to eq([
-      "Running \e[33;1mecho hello\e[0m\n",
-      "\thello\n",
-      "Finished in x seconds with exit status 0 (\e[32;1msuccessful\e[0m)\n"
-    ])
+      command.run(:echo, "hello")
+      output.rewind
+
+      lines = output.readlines
+      lines.last.gsub!(/\d+\.\d+/, "x")
+      expect(lines).to eq([
+        "Running \e[33;1mecho hello\e[0m\n",
+        "\thello\n",
+        "Finished in x seconds with exit status 0 (\e[32;1msuccessful\e[0m)\n"
+      ])
+    end
+
+    it "runs command successfully with logging without uuid set locally" do
+      output = StringIO.new
+      command = TTY::Command.new(output: output)
+
+      command.run(:echo, "hello", uuid: false)
+      output.rewind
+
+      lines = output.readlines
+      lines.last.gsub!(/\d+\.\d+/, "x")
+      expect(lines).to eq([
+        "Running \e[33;1mecho hello\e[0m\n",
+        "\thello\n",
+        "Finished in x seconds with exit status 0 (\e[32;1msuccessful\e[0m)\n"
+      ])
+    end
   end
 
-  it "runs command successfully with logging without uuid set locally" do
-    output = StringIO.new
-    command = TTY::Command.new(output: output)
+  context "with tag option" do
+    it "prints the tag set globally" do
+      output = StringIO.new
+      tag = "task"
+      command = TTY::Command.new(output: output, tag: tag)
 
-    command.run(:echo, "hello", uuid: false)
-    output.rewind
+      command.run(:echo, "hello")
 
-    lines = output.readlines
-    lines.last.gsub!(/\d+\.\d+/, "x")
-    expect(lines).to eq([
-      "Running \e[33;1mecho hello\e[0m\n",
-      "\thello\n",
-      "Finished in x seconds with exit status 0 (\e[32;1msuccessful\e[0m)\n"
-    ])
+      output.rewind
+      lines = output.readlines
+      lines.last.gsub!(/\d+\.\d+/, "x")
+      expect(lines).to eq([
+        "[\e[32m#{tag}\e[0m] Running \e[33;1mecho hello\e[0m\n",
+        "[\e[32m#{tag}\e[0m] \thello\n",
+        "[\e[32m#{tag}\e[0m] Finished in x seconds with exit status 0 " \
+        "(\e[32;1msuccessful\e[0m)\n"
+      ])
+    end
+
+    it "prints the tag set locally" do
+      output = StringIO.new
+      tag = "task"
+      command = TTY::Command.new(output: output)
+
+      command.run(:echo, "hello", tag: tag)
+
+      output.rewind
+      lines = output.readlines
+      lines.last.gsub!(/\d+\.\d+/, "x")
+      expect(lines).to eq([
+        "[\e[32m#{tag}\e[0m] Running \e[33;1mecho hello\e[0m\n",
+        "[\e[32m#{tag}\e[0m] \thello\n",
+        "[\e[32m#{tag}\e[0m] Finished in x seconds with exit status 0 " \
+        "(\e[32;1msuccessful\e[0m)\n"
+      ])
+    end
+
+    it "prints the tag even if uuid is set to false" do
+      output = StringIO.new
+      tag = "task"
+      command = TTY::Command.new(output: output, tag: tag, uuid: false)
+
+      command.run(:echo, "hello")
+
+      output.rewind
+      lines = output.readlines
+      lines.last.gsub!(/\d+\.\d+/, "x")
+      expect(lines).to eq([
+        "[\e[32m#{tag}\e[0m] Running \e[33;1mecho hello\e[0m\n",
+        "[\e[32m#{tag}\e[0m] \thello\n",
+        "[\e[32m#{tag}\e[0m] Finished in x seconds with exit status 0 " \
+        "(\e[32;1msuccessful\e[0m)\n"
+      ])
+    end
   end
 
   it "runs command and fails with logging" do


### PR DESCRIPTION
### Describe the change

This adds a `tag` option to `TTY::Command.new` and the `run` method. This allows you to prepend any arbitrary string to the beginning of log output.

To clearly show the differences from the existing codebase, the commits are split as follows:

- One commit showing the essential changes
- Two commits for test refactoring

### Why are we doing this?

Currently, tty-command's log output only allows you to control whether UUIDs are on or off. Meaningless UUID strings make it very difficult to identify the output of multiple interleaved command executions.

```
$ ruby -rtty-command -e 'cmd=TTY::Command.new; cmd.run("echo rsync from server A"); cmd.run("echo rsync from server B")' 
[9ad3f783] Running echo rsync from server A
[9ad3f783]      rsync from server A
[9ad3f783] Finished in 0.003 seconds with exit status 0 (successful)
[8d98f58b] Running echo rsync from server B
[8d98f58b]      rsync from server B
[8d98f58b] Finished in 0.002 seconds with exit status 0 (successful)
```

### Benefits

By allowing arbitrary strings to be displayed at the beginning of logs, you can easily identify the output of multiple interleaved command executions.

```
$ ruby -rtty-command -e 'cmd=TTY::Command.new; cmd.run("echo rsync from server A", tag: "serverA"); cmd.run("echo rsync from server B", tag: "serverB")' 
[serverA] Running echo rsync from server A
[serverA]      rsync from server A
[serverA] Finished in 0.003 seconds with exit status 0 (successful)
[serverB] Running echo rsync from server B
[serverB]      rsync from server B
[serverB] Finished in 0.002 seconds with exit status 0 (successful)
```

### Drawbacks

None. All existing code will continue to work as before without any modifications.

### Requirements
<!--- Put an X between brackets on each line if you have done the item: -->
- [X] Tests written & passing locally?
- [ ] Code style checked? ==> I ran rubocop but it shows too many errors even in unmodified codebase.
- [X] Rebased with `master` branch?
- [X] Documentation updated?
- [X] Changelog updated?